### PR TITLE
Produce full PDFs of notes and annotated PDFs (including new v6 format)

### DIFF
--- a/rm_tools/rmtool.py
+++ b/rm_tools/rmtool.py
@@ -227,8 +227,15 @@ def convert_file(infile, outfile, rootdir, width, height, debug):
             rm2svg.rm2svg(pagerm, pagesvg, colored_annotations, width, height)
         except:
             rm2svgv6.rm2svg(pagerm, pagesvg)
+
+        # scale svg according to the 157mm x 210mm documents
+        # that RM's renderer outputs for unextended 1872px x 1404px documents
+        px_per_mm_x = width / 210 # for unextended standard notes: 1872 / 210
+        px_per_mm_y = height / 157 # for unextended standard notes: 1404 / 157
+        px_per_in_x = px_per_mm_x * 25.4 # for unextended standard notes: around 226
+        px_per_in_y = px_per_mm_y * 25.4 # for unextended standard notes: around 226
         pagepdf = os.path.join(tmpdir, page_uuid + '.pdf')
-        command = 'inkscape %s --export-filename=%s' % (pagesvg, pagepdf)
+        command = 'rsvg-convert --format=pdf --dpi-x=%f --dpi-y=%f "%s" > "%s"' % (px_per_in_x, px_per_in_y, pagesvg, pagepdf)
         returncode, out, err = run(command, False)
         assert(returncode == 0), command
         pagepdf_list.append(pagepdf)

--- a/rm_tools/rmtool.py
+++ b/rm_tools/rmtool.py
@@ -234,21 +234,22 @@ def convert_file(infile, outfile, rootdir, debug):
         # BG does not exist: 1404px x 1872px (RM screen size) = 157mm x 210mm (exported PDF)
         #                    for unexported notes; scale up with this pixel density if extended
         # BG exists:         obtain BG document's physical size and convert it to RM pixels
+        px_per_mm_x = 1404 / (445 * 25.4 / 72) # for unextended standard notes
+        px_per_mm_y = 1872 / (594 * 25.4 / 72) # for unextended standard notes
         if bg_page_exists:
             bg_page_num = content['cPages']['pages'][page_num]['redir']['value'] # looks like this points to BG PDF page number
             bg_page = bg.pages[bg_page_num]
             bg_width_mm = float(bg_page.mediabox.width) * 25.4 / 72 # mediaBox in user space units (1/72 inch)
             bg_height_mm = float(bg_page.mediabox.height) * 25.4 / 72 # mediaBox in user space units (1/72 inch)
+            bg_width_px = bg_width_mm * px_per_mm_x
+            bg_height_px = bg_height_mm * px_per_mm_y
         else:
-            bg_width_mm = 157
-            bg_height_mm = 210
             bg_page = None
-        px_per_mm_x = 1404 / 157 # for unextended standard notes
-        px_per_mm_y = 1872 / 210 # for unextended standard notes
-        bg_width_px = bg_width_mm * px_per_mm_x
-        bg_height_px = bg_height_mm * px_per_mm_y
+            bg_width_px = 1404
+            bg_height_px = 1872
+            bg_width_mm = bg_width_px / px_per_mm_x
+            bg_height_mm = bg_height_px / px_per_mm_y
 
-        # TODO: make it work when annotations are outside BG bounds
         print(f"Processing page {page_num}. ", end="")
         print(f"FG: {fg_exists}. BG: {bg_page_exists}. ", end="")
         print(f"Size: {bg_width_px:.1f}px x {bg_height_px:.1f}px = {bg_width_mm:.1f}mm x {bg_height_mm:.1f}mm.")

--- a/rm_tools/rmtool.py
+++ b/rm_tools/rmtool.py
@@ -232,10 +232,25 @@ def convert_file(infile, outfile, rootdir, width, height, debug):
         returncode, out, err = run(command, False)
         assert(returncode == 0), command
         pagepdf_list.append(pagepdf)
+
     # put all the pages together
     command = 'pdfunite %s "%s"' % (' '.join(pagepdf_list), outfile)
     returncode, out, err = run(command, False)
     assert(returncode == 0), command
+
+    # if a background PDF exists, render the foreground annotations on top of it
+    bg_pdf_path = os.path.join(rootdir, uuid + '.pdf')
+    if os.path.exists(bg_pdf_path):
+        fg_pdf_path = outfile # what we just rendered above
+        outfile_merged = outfile.removesuffix('.pdf') + '_merged.pdf'
+        command = 'qpdf "%s" --overlay "%s" -- "%s"' % (bg_pdf_path, fg_pdf_path, outfile_merged)
+        returncode, out, err = run(command, False)
+        assert(returncode == 0), command
+
+        # overwrite outfile (foreground only) with outfile_merged (foreground + background)
+        command = 'mv "%s" "%s"' % (outfile_merged, outfile)
+        returncode, out, err = run(command, False)
+        assert(returncode == 0), command
 
 
 def convert_all(rootdir, outdir, width, height, debug):

--- a/rm_tools/rmtool.py
+++ b/rm_tools/rmtool.py
@@ -92,12 +92,24 @@ def get_repo_info(rootdir, debug):
     cur_uuid_list = [rootnode.uuid]
     cur_node = [rootnode]
     prev_node = None
+
+    # define a file to be trashed if it *or its parent* is trashed
+    # this "extended" definition prevents an infinite loop due to
+    # files that are not trashed, but whose parent is trashed (in the unextended definition)
+    def trashed(uuid, metadata):
+        if metadata['parent'] == 'trash':
+            return True
+        for uuid2, metadata2 in node_list:
+            if uuid2 == metadata['parent']:
+                return trashed(uuid2, metadata2)
+        return False
+
     while node_list:
         new_cur_uuid_list = []
         new_cur_node = []
         new_node_list = []
         for uuid, metadata in node_list:
-            if metadata['parent'] == 'trash':
+            if trashed(uuid, metadata):
                 # ignore it
                 pass
             elif metadata['parent'] in cur_uuid_list:

--- a/rm_tools/rmtool.py
+++ b/rm_tools/rmtool.py
@@ -240,7 +240,10 @@ def convert_file(infile, outfile, rootdir, debug):
         # a background (BG) document (like an annotated PDF file),
         # or both
         fg_exists = os.path.exists(page_path)
-        bg_page_exists = os.path.exists(bg_pdf_path) and 'redir' in content['cPages']['pages'][page_num]
+        if content['formatVersion'] == 1:
+            bg_page_exists = os.path.exists(bg_pdf_path) and content['redirectionPageMap'][page_num] >= 0 # TODO: what is redirectionPageMap value for an unannotated page?
+        elif content['formatVersion'] == 2:
+            bg_page_exists = os.path.exists(bg_pdf_path) and 'redir' in content['cPages']['pages'][page_num]
 
         # determine document size based on background (BG)
         # BG does not exist: 1404px x 1872px (RM screen size) = 157mm x 210mm (exported PDF)
@@ -249,7 +252,10 @@ def convert_file(infile, outfile, rootdir, debug):
         px_per_mm_x = 1404 / (445 * 25.4 / 72) # for unextended standard notes
         px_per_mm_y = 1872 / (594 * 25.4 / 72) # for unextended standard notes
         if bg_page_exists:
-            bg_page_num = content['cPages']['pages'][page_num]['redir']['value'] # looks like this points to BG PDF page number
+            if content['formatVersion'] == 1:
+                bg_page_num = content['redirectionPageMap'][page_num] # looks like this points to BG PDF page number
+            elif content['formatVersion'] == 2:
+                bg_page_num = content['cPages']['pages'][page_num]['redir']['value'] # looks like this points to BG PDF page number
             bg_page = bg.pages[bg_page_num]
             bg_width_mm = float(bg_page.mediabox.width) * 25.4 / 72 # mediaBox in user space units (1/72 inch)
             bg_height_mm = float(bg_page.mediabox.height) * 25.4 / 72 # mediaBox in user space units (1/72 inch)


### PR DESCRIPTION
With these changes, `rmtool.py convert-all -r my_raw_remarkable_files/ -o outdir/ -d` successfully converts every (pre-v6 and v6) document on my RM to PDF. It produces sane document sizes, works for pure RM notebooks, annotated PDFs and mixes thereof, handles foreground notes that extend outside the background PDF's area, etc. It is an attempt to make the renderer "universal" again, as it was before the new v6 format, and like the RM USB web interface renderer.

It requires `rsvg-convert` instead of `inkscape` (in the future I think it would be a good idea to avoid all these CLI tools), [PyPDF2](https://github.com/py-pdf/pypdf) instead of `pdfunite` and [rmscene with this small modification](https://github.com/chemag/rmscene/pull/1).

I am interested in whether it works for someone else's RM.